### PR TITLE
fix: Change mxPopupMenu.addItem parent type to Element

### DIFF
--- a/util/mxPopupMenu.d.ts
+++ b/util/mxPopupMenu.d.ts
@@ -128,7 +128,7 @@ declare module 'mxgraph' {
       title: string,
       image?: string,
       funct?: (me: mxMouseEvent) => void,
-      parent?: mxPopupMenu,
+      parent?: Element,
       iconCls?: string,
       enabled?: boolean,
       active?: boolean


### PR DESCRIPTION
The parent parameter to `mxPopupMenu.addItem()` is described as:
`parent - Optional item returned by <addItem>.`
https://github.com/jgraph/mxgraph/blob/master/javascript/src/js/util/mxPopupMenu.js#L189

The return value type of mxPopupMenu.addItem() is `Element`.

This change is needed to support submenus as shown in this example:
https://github.com/jgraph/mxgraph/blob/master/javascript/examples/touch.html#L113-L118