### PR TITLE
fix: mxLayoutManager.getLayout return type now supports null

### DIFF
--- a/view/mxLayoutManager.d.ts
+++ b/view/mxLayoutManager.d.ts
@@ -112,7 +112,7 @@ declare module 'mxgraph' {
      * {@link mxEvent.BEGIN_UPDATE} and {@link mxEvent.END_UPDATE} for the capture
      * and bubble phase of the layout after any changes of the model.
      */
-    getLayout(cell: mxCell, eventName?: string): mxGraphLayout;
+    getLayout(cell: mxCell, eventName?: string): mxGraphLayout | null;
 
     /**
      * Called from {@link undoHandler}.


### PR DESCRIPTION
Null is a valid return value as shown in the folding example, here:
https://github.com/jgraph/mxgraph/blob/master/javascript/examples/folding.html#L90