### PR TITLE
fix: mxGraphModel.getStyle can now return null

### DIFF
--- a/model/mxGraphModel.d.ts
+++ b/model/mxGraphModel.d.ts
@@ -763,7 +763,7 @@ declare module 'mxgraph' {
      *
      * @param {mxCell} cell  whose style should be returned.
      */
-    getStyle(cell: mxCell): string;
+    getStyle(cell: mxCell): string | null;
 
     /**
      * Sets the style of the given {@link mxCell} using {@link mxStyleChange} and


### PR DESCRIPTION
As shown in the collapse example:
https://github.com/jgraph/mxgraph/blob/master/javascript/examples/collapse.html#L30-L47