### PR TITLE
fix: Remove incorrect parameters from mxImageShape.isRoundable.

### DIFF
--- a/shape/mxImageShape.d.ts
+++ b/shape/mxImageShape.d.ts
@@ -60,6 +60,7 @@ declare module 'mxgraph' {
      * Disables inherited roundable support.
      */
     isRoundable(): boolean;
+    isRoundable(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): boolean;
 
     /**
      * Generic background painting implementation.

--- a/shape/mxImageShape.d.ts
+++ b/shape/mxImageShape.d.ts
@@ -59,7 +59,7 @@ declare module 'mxgraph' {
     /**
      * Disables inherited roundable support.
      */
-    isRoundable(c: mxAbstractCanvas2D, x: number, y: number, w: number, h: number): boolean;
+    isRoundable(): boolean;
 
     /**
      * Generic background painting implementation.

--- a/shape/mxRectangleShape.d.ts
+++ b/shape/mxRectangleShape.d.ts
@@ -27,6 +27,7 @@ declare module 'mxgraph' {
     /**
      * Adds roundable support.
      */
+    isRoundable(): boolean;
     isRoundable(c?: mxAbstractCanvas2D, x?: number, y?: number, w?: number, h?: number): boolean;
 
     /**

--- a/shape/mxSwimlane.d.ts
+++ b/shape/mxSwimlane.d.ts
@@ -41,6 +41,7 @@ declare module 'mxgraph' {
      * @param {number} h
      * @returns {boolean}
      */
+    isRoundable(): boolean;
     isRoundable(c?: mxAbstractCanvas2D, x?: number, y?: number, w?: number, h?: number): boolean;
 
     /**


### PR DESCRIPTION
The base class implementation in `mxShape` for this function is:
https://github.com/jgraph/mxgraph/blob/master/javascript/src/js/shape/mxShape.js#L1433

The overridden implementation in `mxImageShape` incorrectly shows the function as taking in parameters:
https://github.com/jgraph/mxgraph/blob/master/javascript/src/js/shape/mxImageShape.js#L125

Unless these parameters are removed from mxImageShape, it's not possible to call `mxCellRenderer.registerShape()` because these function signatures don't match and so TS doesn't consider it a valid subclass.
https://github.com/typed-mxgraph/typed-mxgraph/blob/master/view/mxCellRenderer.d.ts#L83

