### PR TITLE
fix: mxShape.getLabelMargins() may now return null

### DIFF
--- a/shape/mxShape.d.ts
+++ b/shape/mxShape.d.ts
@@ -449,7 +449,7 @@ declare module 'mxgraph' {
      * computing the label bounds as an <mxRectangle>, where the bottom and right
      * margin are defined in the width and height of the rectangle, respectively.
      */
-    getLabelMargins(rect: mxRectangle): mxRectangle;
+    getLabelMargins(rect: mxRectangle): mxRectangle | null;
 
     /**
      * Function: checkBounds


### PR DESCRIPTION
As shown is valid in the Graph Editor example for creating a cube shape:
https://github.com/jgraph/mxgraph/blob/master/javascript/examples/grapheditor/www/js/Shapes.js#L302-L312