### PR TITLE
fix: mxUtils.getValue takes Record, not Array

### DIFF
--- a/util/mxUtils.d.ts
+++ b/util/mxUtils.d.ts
@@ -16,7 +16,10 @@ declare module 'mxgraph' {
      * @param key             Key whose value should be returned.
      * @param defaultValue    Value to be returned if the value for the given key is null.
      */
-    static getValue(array: Array<any>, key: any, defaultValue: any): any;
+    static getValue(
+      array: Record<string | number | symbol, any> | undefined, 
+      key: string | number | symbol, 
+      defaultValue: any): any;
 
     /**
      * Returns true if the specified point (x, y) is contained in the given rectangle.

--- a/util/mxUtils.d.ts
+++ b/util/mxUtils.d.ts
@@ -17,9 +17,10 @@ declare module 'mxgraph' {
      * @param defaultValue    Value to be returned if the value for the given key is null.
      */
     static getValue(
-      array: Record<string | number | symbol, any> | undefined, 
-      key: string | number | symbol, 
-      defaultValue: any): any;
+      array: Record<string | number | symbol, any> | undefined,
+      key: string | number | symbol,
+      defaultValue: any
+    ): any;
 
     /**
      * Returns true if the specified point (x, y) is contained in the given rectangle.


### PR DESCRIPTION
The documentation refers to an `Associative Array`, which is a Map not an Array.
https://github.com/jgraph/mxgraph/blob/master/javascript/src/js/util/mxUtils.js#L1736

The main use for this function in the source is to access the StyleMap values. These are key-value pairs. For example, do a Ctrl+F on 'getValue' here:
https://github.com/jgraph/mxgraph/blob/master/javascript/examples/grapheditor/www/js/Shapes.js#L304