### PR TITLE
mxPrintPreview.open() : All parameters now optional

### DIFF
--- a/view/mxPrintPreview.d.ts
+++ b/view/mxPrintPreview.d.ts
@@ -341,7 +341,7 @@ declare module 'mxgraph' {
      * @param targetWindow Optional window that should be used for rendering. If
      * this is specified then no HEAD tag, CSS and BODY tag will be written.
      */
-    open(css: string, targetWindow?: Window, forcePageBreaks?: boolean, keepOpen?: boolean): Window;
+    open(css?: string, targetWindow?: Window, forcePageBreaks?: boolean, keepOpen?: boolean): Window;
 
     /**
      * Adds a page break to the given document.


### PR DESCRIPTION
Source docs describe it as optional: https://github.com/jgraph/mxgraph/blob/master/javascript/src/js/view/mxPrintPreview.js#L401

It's also used this way in mxEditor's source: https://github.com/jgraph/mxgraph/blob/master/javascript/src/js/editor/mxEditor.js#L1008
