### PR TITLE
fixed. #29  

### DIFF
--- a/lib/util/mxUtils.d.ts
+++ b/lib/util/mxUtils.d.ts
@@ -559,7 +559,7 @@ declare module 'mxgraph' {
      * @param {string} [newline='\n'] Option string that represents a linefeed. Default is '\n'.
      * @param ns
      */
-    static getPrettyXML(node: XMLDocument, tab?: string, indent?: string, newline?: string, ns?: any): string;
+    static getPrettyXml(node: XMLDocument, tab?: string, indent?: string, newline?: string, ns?: any): string;
 
     /**
      * Returns the text content of the specified node.

--- a/tests/util/mxUtils.spec.ts
+++ b/tests/util/mxUtils.spec.ts
@@ -15,4 +15,8 @@ describe('factory', () => {
     [].sort(compareFn);
   });
 
+  it('mxUtils.getPrettyXml should be a function', () => {
+    expect(typeof(mx.mxUtils.getPrettyXml)).toEqual('function');
+  });
+
 });


### PR DESCRIPTION
The function name has been changed to the official name. getPrettyXML -> getPrettyXml