### PR TITLE
fix: improve mxCellOverlay types

### DIFF
--- a/lib/shape/mxShape.d.ts
+++ b/lib/shape/mxShape.d.ts
@@ -324,6 +324,10 @@ declare module 'mxgraph' {
      */
     useSvgBoundingBox: boolean;
 
+    // https://github.com/jgraph/mxgraph/blob/v4.2.2/javascript/src/js/view/mxCellRenderer.js#L562
+    // set the property on mxShape and not only on mxImageShape to allow mxCellOverlay extension
+    overlay: mxCellOverlay;
+
     /**
      * Function: init
      *

--- a/lib/util/mxDictionary.d.ts
+++ b/lib/util/mxDictionary.d.ts
@@ -3,66 +3,48 @@ declare module 'mxgraph' {
     constructor();
 
     /**
-     * Function: map
-     *
      * Stores the (key, value) pairs in this dictionary.
      */
-    map: { [key: string]: T };
+    map: { [key: any]: T };
 
     /**
-     * Function: clear
-     *
      * Clears the dictionary.
      */
     clear(): void;
 
     /**
-     * Function: get
-     *
      * Returns the value for the given key.
      */
     get(key: any): T;
 
     /**
-     * Function: put
-     *
      * Stores the value under the given key and returns the previous
      * value for that key.
      */
     put(key: any, value: T): T;
 
     /**
-     * Function: remove
-     *
      * Removes the value for the given key and returns the value that
      * has been removed.
      */
-    remove(key: string): T;
+    remove(key: any): T;
 
     /**
-     * Function: getKeys
-     *
      * Returns all keys as an array.
      */
-    getKeys(): string[];
+    getKeys(): any[];
 
     /**
-     * Function: getValues
-     *
      * Returns all values as an array.
      */
     getValues(): T[];
 
     /**
-     * Function: visit
-     *
      * Visits all entries in the dictionary using the given function with the
      * following signature: function(key, value) where key is a string and
      * value is an object.
      *
-     * Parameters:
-     *
-     * visitor - A function that takes the key and value as arguments.
+     * @param visitor A function that takes the key and value as arguments.
      */
     visit(visitor: (key: string, value: T) => void): void;
   }

--- a/lib/view/mxCellState.d.ts
+++ b/lib/view/mxCellState.d.ts
@@ -109,6 +109,10 @@ declare module 'mxgraph' {
      */
     text: mxText;
 
+    // used in https://github.com/jgraph/mxgraph/blob/v4.2.2/javascript/src/js/view/mxCellRenderer.js#L555
+    // set the type to mxShape and not only to mxImageShape to allow mxCellOverlay extension
+    overlays: mxDictionary<mxShape>;
+
     /**
      * Variable: unscaledWidth
      *


### PR DESCRIPTION
mxDictionary:
  - fix TSDoc
  - fix remove and getKeys signatures: switch from 'string' to 'any', for
  consistency with the 'get' and 'put' methods

mxCellState: add overlays property used in mxCellRenderer

mxShape: add overlay property used in mxCellRenderer

cc @csouchet @aibcmars