### PR TITLE
fix: make mxText assignable to mxShape

### DIFF
--- a/lib/shape/mxText.d.ts
+++ b/lib/shape/mxText.d.ts
@@ -58,25 +58,25 @@ declare module 'mxgraph' {
       textDirection?: string
     );
 
-    protected value: string;
-    protected color: string;
-    protected valign: string;
-    protected align: string;
-    protected family: string;
-    protected size: number;
-    protected fontStyle: number;
-    protected spacingTop: number;
-    protected spacingRight: number;
-    protected spacingBottom: number;
-    protected spacingLeft: number;
-    protected horizontal: boolean;
-    protected background: string;
-    protected border: string;
-    protected wrap: boolean;
-    protected clipped: boolean;
-    protected overflow: string;
-    protected labelPadding: string;
-    protected textDirection: string;
+    value: string;
+    color: string;
+    valign: string;
+    align: string;
+    family: string;
+    size: number;
+    fontStyle: number;
+    spacingTop: number;
+    spacingRight: number;
+    spacingBottom: number;
+    spacingLeft: number;
+    horizontal: boolean;
+    background: string;
+    border: string;
+    wrap: boolean;
+    clipped: boolean;
+    overflow: string;
+    labelPadding: string;
+    textDirection: string;
 
     /**
      * Specifies the spacing to be added to the top spacing. Use the

--- a/lib/shape/mxText.d.ts
+++ b/lib/shape/mxText.d.ts
@@ -59,14 +59,12 @@ declare module 'mxgraph' {
     );
 
     protected value: string;
-    protected bounds: mxRectangle;
     protected color: string;
     protected valign: string;
     protected align: string;
     protected family: string;
     protected size: number;
     protected fontStyle: number;
-    protected spacing: number;
     protected spacingTop: number;
     protected spacingRight: number;
     protected spacingBottom: number;

--- a/tests/shape/mxText.spec.ts
+++ b/tests/shape/mxText.spec.ts
@@ -1,0 +1,16 @@
+/// <reference path="../../index.d.ts" />
+import factory, { mxGraphExportObject, mxRectangle, mxShape, mxText } from 'mxgraph';
+
+describe('mxText', () => {
+  let mx: mxGraphExportObject;
+
+  beforeAll(() => {
+    mx = factory();
+  });
+
+  it('mxText instance should be assignable to mxShape variables', () => {
+    const shape: mxShape = new mx.mxText('a label', new mx.mxRectangle(0, 10, 30, 100));
+
+    expect(shape).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Some fields were redeclared as protected whereas there are public in the mxShape
super class.

---
Introduced in `1.0.1` by #32
Detected with https://github.com/process-analytics/bpmn-visualization-js/pull/1224

cc @csouchet @aibcmars