### PR TITLE
fix: restore mxDictionary map index signature parameter set to string

### DIFF
--- a/lib/util/mxDictionary.d.ts
+++ b/lib/util/mxDictionary.d.ts
@@ -5,7 +5,10 @@ declare module 'mxgraph' {
     /**
      * Stores the (key, value) pairs in this dictionary.
      */
-    map: { [key: any]: T };
+    // the key is always a string
+    // https://github.com/jgraph/mxgraph/blob/v4.2.2/javascript/src/js/util/mxDictionary.js#L44: call mxObjectIdentity.get(key)
+    // https://github.com/jgraph/mxgraph/blob/v4.2.2/javascript/src/js/util/mxObjectIdentity.js#L36: always returns a string
+    map: { [key: string]: T };
 
     /**
      * Clears the dictionary.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "es5",
     "module": "commonjs",
     "strict": true,
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true
   },


### PR DESCRIPTION
Fix error TS1023: An index signature parameter type must be either 'string' or
'number'. In addition, references to mxgraph javascript code is available to
explain why the key is a string.

`skipLibCheck` is now set to `false` in the tsconfig.json file. So, tsc run
prior checking the tests will fail in case of TS errors and we will be alerted
before integrating such problem in the repository.
Projects integrating typed-mxgraph will also be able to use this option without
errors coming from the mxgraph types.