### PR TITLE
fix(mxText): labelPadding field is a number

### DIFF
--- a/lib/shape/mxText.d.ts
+++ b/lib/shape/mxText.d.ts
@@ -75,7 +75,7 @@ declare module 'mxgraph' {
     wrap: boolean;
     clipped: boolean;
     overflow: string;
-    labelPadding: string;
+    labelPadding: number;
     textDirection: string;
 
     /**


### PR DESCRIPTION
It is now consistent with the constructor parameter.