### PR TITLE
Update mxEditor.d.ts

### DIFF
--- a/lib/editor/mxEditor.d.ts
+++ b/lib/editor/mxEditor.d.ts
@@ -1266,7 +1266,7 @@ declare module 'mxgraph' {
      * @param source
      * @param target
      */
-    createEdge(source: any, target: any): void;
+    createEdge(source: any, target: any): any;
 
     /**
      * Returns a string identifying the style of new edges.

--- a/lib/editor/mxEditor.d.ts
+++ b/lib/editor/mxEditor.d.ts
@@ -1266,7 +1266,7 @@ declare module 'mxgraph' {
      * @param source
      * @param target
      */
-    createEdge(source: any, target: any): any;
+    createEdge(source: any, target: any): mxCell;
 
     /**
      * Returns a string identifying the style of new edges.


### PR DESCRIPTION
createEdge function needed to return 'any' instead of 'void'.

Otherwise the editor can not draw edges.

Tested in Angular.