### PR TITLE
fix(mxConstants): const values used as types

### DIFF
--- a/lib/util/mxConstants.d.ts
+++ b/lib/util/mxConstants.d.ts
@@ -349,13 +349,13 @@ declare module 'mxgraph' {
      * Defines the dashed state to be used for the vertex selection
      * border. Default is true.
      */
-    static VERTEX_SELECTION_DASHED: true;
+    static VERTEX_SELECTION_DASHED: boolean;
 
     /**
      * Defines the dashed state to be used for the edge selection
      * border. Default is true.
      */
-    static EDGE_SELECTION_DASHED: true;
+    static EDGE_SELECTION_DASHED: boolean;
 
     /**
      * Defines the color to be used for the guidelines in mxGraphHandler.


### PR DESCRIPTION
Fixes a type error when assigning `FALSE` 