### PR TITLE
doc: improve the "import type" syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ mxGraph Typescript Declarations For [Official mxGraph NPM Package][mxgraph].
     ```ts
     // src/application.ts
     import mx from './mxgraph';                       // <- import values from factory()
-    import { mxGraph, mxGraphModel } from 'mxgraph';  // <- import types only
+    import type { mxGraph, mxGraphModel } from 'mxgraph';  // <- import types only, "import type" is a TypeScript 3.8+ syntax
 
     export class Application {
 


### PR DESCRIPTION
Use the TypeScript 3.8+ "import type" syntax to clarify the value and type imports.
See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export

If this PR is accepted, I will then update https://github.com/typed-mxgraph/typed-mxgraph-example-bundled-with-rollup and https://github.com/typed-mxgraph/typed-mxgraph-example-bundled-with-webpack