### PR TITLE
chore: remove mxgraph from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,8 @@
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3"
   },
-  "peerDependencies": {
-    "mxgraph": "^4.2.2"
-  },
   "description": "mxGraph typescript declarations",
   "main": "index.d.ts",
-  "dependencies": {},
   "repository": {
     "type": "git",
     "url": "git+https://github.com/typed-mxgraph/typed-mxgraph.git"


### PR DESCRIPTION
Type libraries almost never declare the underlying js library as peerDependencies.
I have checked a lot of projects at DefinitelyTyped.
At least, this is not the way to express that the type library is targeting a
specific version of the js library.