### PR TITLE
fix(mxGraph): make the center parameter optional

### DIFF
--- a/lib/view/mxGraph.d.ts
+++ b/lib/view/mxGraph.d.ts
@@ -2548,7 +2548,7 @@ declare module 'mxgraph' {
      * argument that keeps the graph scrolled to the center. If the center argument
      * is omitted, then {@link centerZoom} will be used as its value.
      */
-    zoom(factor: number, center: boolean): void;
+    zoom(factor: number, center?: boolean): void;
 
     /**
      * Zooms the graph to the specified rectangle. If the rectangle does not have same aspect


### PR DESCRIPTION
This is what is implemented and documented, so fix the type.

Implementation: https://github.com/jgraph/mxgraph/blob/v4.2.2/javascript/src/js/view/mxGraph.js#L8042-L8046