### PR TITLE
fix: don't use `any` in signature of the mxGraphModel filter functions

### DIFF
--- a/lib/model/mxGraphModel.d.ts
+++ b/lib/model/mxGraphModel.d.ts
@@ -1,3 +1,5 @@
+import { mxCell } from 'mxgraph';
+
 declare module 'mxgraph' {
   /**
    * Extends {@link mxEventSource} to implement a graph model. The graph model acts as
@@ -280,7 +282,7 @@ declare module 'mxgraph' {
      * Returns the cells from the given array where the given filter function
      * returns true.
      */
-    filterCells(cells: Array<mxCell>, filter: (...args: any) => boolean): Array<mxCell>;
+    filterCells(cells: Array<mxCell>, filter: (cell: mxCell) => boolean): Array<mxCell>;
 
     /**
      * Returns all descendants of the given cell and the cell itself in an array.
@@ -309,7 +311,7 @@ declare module 'mxgraph' {
      * and returns a boolean.
      * @param parent  Optional {@link mxCell} that is used as the root of the recursion.
      */
-    filterDescendants(filter: (...args: any) => boolean, parent?: mxCell): Array<mxCell>;
+    filterDescendants(filter: (cell: mxCell) => boolean, parent?: mxCell): Array<mxCell>;
 
     /**
      * Returns the root of the model or the topmost parent of the given cell.

--- a/tests/model/mxGraphModel.spec.ts
+++ b/tests/model/mxGraphModel.spec.ts
@@ -1,0 +1,38 @@
+/// <reference path="../../index.d.ts" />
+import factory, { mxCell, mxGraphExportObject } from 'mxgraph';
+
+
+describe('mxGraphModel', () => {
+  let mx: mxGraphExportObject;
+
+  beforeAll(() => {
+    mx = factory();
+  });
+
+  const newEdge = (name: string): mxCell => {
+    const cell = new mx.mxCell('cell2');
+    cell.setEdge(true);
+    return cell;
+  };
+
+  it('filterDescendants: accept filter by cell', () => {
+    const parent = new mx.mxCell('root');
+    const model = new mx.mxGraphModel(parent);
+    const child = newEdge('child');
+    model.add(parent, child);
+    const filteredCells = model.filterDescendants((cell: mxCell) => {
+      return cell.isEdge();
+    });
+    expect(filteredCells).toEqual([child]);
+  });
+
+  it('filterCells: accept filter by cell', () => {
+    const cell2 = newEdge('cell2');
+    const model = new mx.mxGraphModel(new mx.mxCell('root'));
+    const filteredCells = model.filterCells([new mx.mxCell('cell1'), cell2, new mx.mxCell('cell3')], (cell: mxCell) => {
+      return cell.isEdge();
+    });
+    expect(filteredCells).toEqual([cell2]);
+  });
+
+});


### PR DESCRIPTION
The filters only apply to `mxCell` so simplify the signature of filter functions and remove `any`.

### Rationale
- `filterCells`: https://github.com/jgraph/mxgraph/blob/v4.2.2/javascript/src/js/model/mxGraphModel.js#L361-L382
- `filterDescendants`: https://github.com/jgraph/mxgraph/blob/v4.2.2/javascript/src/js/model/mxGraphModel.js#L401-L450